### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,7 +8,7 @@
 
 IMAPData	KEYWORD1
 SMTPData	KEYWORD1
-attachmentData  KEYWORD1
+attachmentData	KEYWORD1
 SendStatus	KEYWORD1
 messageBodyData	KEYWORD1
 DownloadProgress	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords