### PR TITLE
Add a limitation section because pb in interrup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ From Arduino IDE, goto menu **Sketch** -> **Include Library** -> **Add .ZIP Libr
 Go to menu **Files** -> **Examples** -> **ESP32-Mail-Client-master** and choose one from examples
 
 
+## Limitation
+
+The library cannot be used in an **interrup** define by attacheInterrup(...), because of a limitation in FreeRTOS (ROM functions and  Wifi function not allowed in a interrupt callback, TBD: find source of that). If you need to do that, you can set a Flag, and use it in the main loop() function to send the email.
+
 
 ## Usages
 


### PR DESCRIPTION
Dear @mobizt , first congratulations for your very extensive email lib ;-)
I would like to add this section ("Limitation"), because I spent lot of time to try to send an email in an "Interrup", and my ESP32 crash systematicaly when sending email. My use case is a PIR sensor that start an interupt. You can rephrase or change totaly this content ;-), but the idea is to inform your user that they will have an hard-time if the try to send email in interrup (like me !)
Regards,
Nicolas.