### PR TITLE
Some details to be able to use GMAIL SMTP server

### DIFF
--- a/examples/Send_email/Send_email.ino
+++ b/examples/Send_email/Send_email.ino
@@ -13,6 +13,7 @@
 
 
 //To use send Email for Gmail to port 465 (SSL), less secure app option should be enabled. https://myaccount.google.com/lesssecureapps?pli=1
+//To authenticate on Gmail SMTP server, you need to unlock Captcha https://accounts.google.com/DisplayUnlockCaptcha , and send an email with your device in the next 10 mn. Need to be done only one time (it's permanent after).
 
 //To receive Email for Gmail, IMAP option should be enabled. https://support.google.com/mail/answer/7126229?hl=en
 


### PR DESCRIPTION
@mobizt ,
Other experience on my side ...
I Need to unlock captcha, and send an email in the next 10 mn WITH the device (esp32), if not I wasn't able to send email with GMAIL smtp server (don't know if it for ALL gmail account ... but my gmail need that, was created only several hours before used ... perhaps it's why I had to do that ... but check here also: https://support.google.com/mail/thread/20278990?hl=en
Regards,
Nico.